### PR TITLE
Define request and response types

### DIFF
--- a/pushy-client.cabal
+++ b/pushy-client.cabal
@@ -29,6 +29,7 @@ source-repository head
 library
   exposed-modules: PushyClient
                  , Types.PushyRequest
+                 , Types.PushyResponse
   hs-source-dirs:  src
   build-depends:   base >=4.7 && <5
                  , aeson

--- a/pushy-client.cabal
+++ b/pushy-client.cabal
@@ -27,8 +27,8 @@ source-repository head
   location: https://github.com/githubuser/pushy-client
 
 library
-  exposed-modules: Lib
-                 , PushyClient
+  exposed-modules: PushyClient
+                 , Types.PushyRequest
   hs-source-dirs:  src
   build-depends:   base >=4.7 && <5
                  , aeson
@@ -44,18 +44,6 @@ library
                  , scientific
                  , text ^>= 1.2
                  , time
-  default-language: Haskell2010
-
-executable pushy-client-exe
-  main-is: Main.hs
-  other-modules:
-      Paths_pushy_client
-  hs-source-dirs:
-      app
-  ghc-options: -threaded -rtsopts -with-rtsopts=-N
-  build-depends:
-      base >=4.7 && <5
-    , pushy-client
   default-language: Haskell2010
 
 test-suite pushy-client-test

--- a/pushy-client.cabal
+++ b/pushy-client.cabal
@@ -28,6 +28,7 @@ source-repository head
 
 library
   exposed-modules: PushyClient
+                 , MakeMockRequest
                  , Types.PushyRequest
                  , Types.PushyResponse
   hs-source-dirs:  src

--- a/pushy-client.cabal
+++ b/pushy-client.cabal
@@ -28,7 +28,7 @@ source-repository head
 
 library
   exposed-modules: PushyClient
-                 , MakeMockRequest
+                 , MockRequest
                  , Types.PushyRequest
                  , Types.PushyResponse
   hs-source-dirs:  src

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -1,6 +1,0 @@
-module Lib
-    ( someFunc
-    ) where
-
-someFunc :: Int -> Int
-someFunc = (+) 3

--- a/src/MockRequest.hs
+++ b/src/MockRequest.hs
@@ -1,6 +1,12 @@
-module MakeMockRequest
+{-# LANGUAGE OverloadedStrings #-}
+
+module MockRequest
     ( makeMockPushyRequest
     ) where
+
+import           PushyClient           (makePushyPostRequest)
+import           Types.PushyRequest    (defaultPushyPostRequestBody)
+import           Types.PushyResponse   (PushyResult)
 
 import           Data.Aeson
 import qualified Data.ByteString       as B
@@ -8,8 +14,9 @@ import qualified Data.ByteString.Char8 as B8
 import qualified Data.Text             as D
 
 
+
 -- | Sample payload type containing PN message; uses the key 'message'
-newtype BodyData = BodyData T.Text deriving (Show)
+newtype BodyData = BodyData D.Text deriving (Show)
 
 instance ToJSON BodyData where
     toJSON (BodyData msg) = object ["message" .= toJSON msg]
@@ -22,7 +29,7 @@ instance ToJSON BodyData where
 makeMockPushyRequest :: String -- ^ API key
                      -> String -- ^ Receiever token
                      -> String -- ^ Message to be sent
-                     -> IO PushyResult BodyData
+                     -> IO PushyResult
 makeMockPushyRequest apiKey deviceToken msg =
     let byteStringApiKey = B8.pack apiKey
         textDeviceToken = D.pack deviceToken

--- a/src/PushyClient.hs
+++ b/src/PushyClient.hs
@@ -1,4 +1,6 @@
-{-# LANGUAGE MultiWayIf          #-}
+-- | Types to capture the request schema for Pushy's external push notification
+-- API; see https://pushy.me/docs/api/send-notifications for more information
+
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -29,7 +31,7 @@ instance ToJSON BodyData where
 -- | Type to represent the iOS notification settings
 data IosNotification = IosNotification
     { inBody  :: T.Text
---    , inBadge :: Int
+    , inBadge :: Int
     , inSound :: T.Text
     } deriving (Show)
 
@@ -37,16 +39,16 @@ data IosNotification = IosNotification
 defaultIosNotificationSettings :: IosNotification
 defaultIosNotificationSettings =
     let inBody =  "Hello"
---        inBadge = 1
+        inBadge = 1
         inSound = T.pack "ping.aiff"
     in IosNotification {..}
 
 instance ToJSON IosNotification where
     toJSON IosNotification {..} =
-        object [ "body"  .= inBody
-  --             , "badge" .= inBadge
-               , "sound" .= inSound
-               ]
+      object [ "body"  .= inBody
+             , "badge" .= inBadge
+             , "sound" .= inSound
+             ]
 
 -- | Type to represent the body of an HTTP POST request to the Pushy API
 data PushyPostRequestBody = PushyPostRequestBody

--- a/src/PushyClient.hs
+++ b/src/PushyClient.hs
@@ -6,86 +6,37 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module PushyClient
-    ( foo
-    , makePushyPostRequest
-    , viewRequestBody
+    ( makePushyPostRequest
+    , makeMockPushyRequest
     ) where
+
+
+import           Types.PushyRequest    (BodyData (..), IosNotification (..),
+                                        PushyPostRequestBody (..),
+                                        defaultIosNotification,
+                                        defaultPushyPostRequestBody)
+import           Types.PushyResponse   (FailureInfo (..), PushyResult (..),
+                                        SuccessInfo (..), decodePushyResponse)
 
 import           Control.Monad.Catch
 import           Data.Aeson
+import           Network.HTTP.Client
+import           Network.HTTP.Simple
+import           Network.HTTP.Types
+
 import qualified Data.ByteString       as B
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.ByteString.Lazy  as L
 import qualified Data.Text             as D
 import qualified Data.Text             as T
-import           Network.HTTP.Client
-import           Network.HTTP.Simple
-import           Network.HTTP.Types
 
--- | Type to represent the body containing the message
-newtype BodyData = BodyData T.Text deriving (Show)
-
-instance ToJSON BodyData where
-    toJSON (BodyData msg) = object ["message" .= toJSON msg]
-
--- | Type to represent the iOS notification settings
-data IosNotification = IosNotification
-    { inBody  :: T.Text
-    , inBadge :: Int
-    , inSound :: T.Text
-    } deriving (Show)
-
--- | Default iOS notification setting
-defaultIosNotificationSettings :: IosNotification
-defaultIosNotificationSettings =
-    let inBody =  "Hello"
-        inBadge = 1
-        inSound = T.pack "ping.aiff"
-    in IosNotification {..}
-
-instance ToJSON IosNotification where
-    toJSON IosNotification {..} =
-      object [ "body"  .= inBody
-             , "badge" .= inBadge
-             , "sound" .= inSound
-             ]
-
--- | Type to represent the body of an HTTP POST request to the Pushy API
-data PushyPostRequestBody = PushyPostRequestBody
-    { to           :: T.Text
-    , bodyData     :: BodyData
-    , notification :: IosNotification
-    } deriving (Show)
-
-instance ToJSON PushyPostRequestBody where
-    toJSON (PushyPostRequestBody to bodyData notification) =
-        object [ "to" .= toJSON to
-               , "data" .= toJSON bodyData
-               , "notification" .= toJSON notification
-               ]
-
--- | Function to construct the Pushy HTTP POST request body, given the recipient ID and the
--- PN message
-constructPushyPostRequestBody :: T.Text -- ^ recipient ID
-                              -> T.Text -- ^ PN message
-                              -> PushyPostRequestBody
-constructPushyPostRequestBody recId msg =
-    let to = recId
-        bodyData = BodyData msg
-        notification = defaultIosNotificationSettings
-    in PushyPostRequestBody{..}
-
-viewRequestBody :: String -> String -> L.ByteString
-viewRequestBody recId msg =
-  let parsedReqBody = constructPushyPostRequestBody (D.pack recId) (D.pack msg)
-  in encode parsedReqBody
 
 -- | Function to contruct the Pushy HTTP POST request
 constructPushyPostRequest :: B.ByteString -- ^ API key
                           -> T.Text -- ^ recipient ID
                           -> T.Text -- ^ message to be posted
                           -> Request
-constructPushyPostRequest apiKey recId msg = do
+constructPushyPostRequest apiKey deviceToken msg = do
     let initReq = parseRequest_ pushyApiPath
       in initReq
          { method = "POST"
@@ -101,40 +52,25 @@ constructPushyPostRequest apiKey recId msg = do
     pushyQueryString = "api_key=" <> apiKey
 
     pushyRequestBody :: RequestBody
-    pushyRequestBody = RequestBodyLBS $ encode $ constructPushyPostRequestBody recId msg
-
--- | Datatype to represent possible results of pushy request
-data PushyResult =  SuccessfulRequest
-                 | HttpLibError
-                 | FailureStatusCode Request Int L.ByteString
-                 deriving (Show)
-
-
--- | Datatype to represent possible error codes:
--- data ErrorCode =  ErrorCode300
---                | ErrorCode400
---                | Other
+    pushyRequestBody = RequestBodyLBS $
+                       encode $
+                       defaultPushyPostRequestBody deviceToken (BodyData msg)
 
 -- | Function to ping the Pushy API endpoint
 makePushyPostRequest :: B.ByteString -- ^ API key
-                     -> T.Text -- ^ recipient ID
-                     -> T.Text -- ^ message to be posted
+                     -> T.Text -- ^ Device token
+                     -> T.Text -- ^ Message
                      -> IO PushyResult
-makePushyPostRequest apiKey recId msg =
-    handle (\ (he :: HttpException) -> pure HttpLibError) $
-    let hReq = constructPushyPostRequest apiKey recId msg
+makePushyPostRequest apiKey deviceToken msg  =
+    handle (\ (he :: HttpException) -> pure $ PushyResultOtherFailure "Http lib error") $
+    let hReq = constructPushyPostRequest apiKey deviceToken msg
     in do
         hRes <- httpLBS hReq
-        pure $ decodeRes hReq (responseStatus hRes) (responseBody hRes)
+        pure $ decodePushyResponse hRes
   where
-    decodeRes :: Request -> Status -> L.ByteString -> PushyResult
-    decodeRes r s b =
-        if  200 <= statusCode s && statusCode s < 300
-        then SuccessfulRequest
-        else FailureStatusCode r (statusCode s) b
 
-foo :: String -> String -> String -> IO PushyResult
-foo apiKey recId msg =
+makeMockPushyRequest :: String -> String -> String -> IO PushyResult
+makeMockPushyRequest apiKey recId msg =
     let byteStringApiKey = B8.pack apiKey
         textRecId = D.pack recId
         textMsg = D.pack msg

--- a/src/Types/MakeMockRequest.hs
+++ b/src/Types/MakeMockRequest.hs
@@ -1,0 +1,31 @@
+module MakeMockRequest
+    ( makeMockPushyRequest
+    ) where
+
+import           Data.Aeson
+import qualified Data.ByteString       as B
+import qualified Data.ByteString.Char8 as B8
+import qualified Data.Text             as D
+
+
+-- | Sample payload type containing PN message; uses the key 'message'
+newtype BodyData = BodyData T.Text deriving (Show)
+
+instance ToJSON BodyData where
+    toJSON (BodyData msg) = object ["message" .= toJSON msg]
+
+
+-- | Utility to make pushy post requests with a secret key and a device token for some
+-- a pushy account. This only requires the API key, the device token, and the message to
+-- be specified; the function then uses the default 'PushyPostRequestBody' value to construct
+-- the request and ping the Pushy external API endpoint. Run this function on the REPL.
+makeMockPushyRequest :: String -- ^ API key
+                     -> String -- ^ Receiever token
+                     -> String -- ^ Message to be sent
+                     -> IO PushyResult BodyData
+makeMockPushyRequest apiKey deviceToken msg =
+    let byteStringApiKey = B8.pack apiKey
+        textDeviceToken = D.pack deviceToken
+        textMsg = D.pack msg
+        pprBody = defaultPushyPostRequestBody textDeviceToken $ BodyData textMsg
+    in makePushyPostRequest byteStringApiKey pprBody

--- a/src/Types/PushyRequest.hs
+++ b/src/Types/PushyRequest.hs
@@ -11,13 +11,8 @@ module Types.PushyRequest
     ) where
 
 import           Data.Aeson
-import           Data.Map
 
-import qualified Data.ByteString       as B
-import qualified Data.ByteString.Char8 as B8
-import qualified Data.ByteString.Lazy  as L
-import qualified Data.Text             as D
-import qualified Data.Text             as T
+import qualified Data.Text  as T
 
 
 -- | Type to represent the body containing the message
@@ -73,7 +68,9 @@ instance ToJSON IosNotification where
                , "title_loc_args" .= inTitleLocArgs
                ]
 
--- | Default iOS notification setting
+-- | Default iOS notification setting. Use this to build a custom 'IosNotification' value.
+-- The iOS notification setting, if at all added to the 'PushyPostRequestBody' value,
+-- must contain text that constitutes the body of the PN.
 defaultIosNotification :: T.Text -> IosNotification
 defaultIosNotification body =
     let inBody =  body
@@ -124,6 +121,9 @@ instance ToJSON PushyPostRequestBody where
                , "notification"      .= pprbNotification
                ]
 
+-- | The default value for a pushy post request body. Use this to construct custom
+-- Pushy post request bodies. Note that a 'PushyPostRequestBody' value must always have
+-- device token and a message.
 defaultPushyPostRequestBody :: T.Text -- ^ The unique device token must be provided
                             -> BodyData -- ^ The body must be provided
                             -> PushyPostRequestBody

--- a/src/Types/PushyRequest.hs
+++ b/src/Types/PushyRequest.hs
@@ -3,8 +3,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Types.PushyRequest
-    ( BodyData (..)
-    , IosNotification (..)
+    ( IosNotification (..)
     , defaultIosNotification
     , PushyPostRequestBody (..)
     , defaultPushyPostRequestBody
@@ -120,22 +119,16 @@ instance (ToJSON payload) => ToJSON (PushyPostRequestBody payload) where
 -- | The default value for a pushy post request body. Use this to construct custom
 -- Pushy post request bodies. Note that a 'PushyPostRequestBody' value must always have
 -- device token and a message.
-
--- | Type to represent the body containing the message
-newtype BodyData = BodyData T.Text deriving (Show)
-
-instance ToJSON BodyData where
-    toJSON (BodyData msg) = object ["message" .= toJSON msg]
-
-
-defaultPushyPostRequestBody :: T.Text -- ^ The unique device token must be provided
-                            -> BodyData -- ^ The body must be provided
-                            -> PushyPostRequestBody
+defaultPushyPostRequestBody :: (ToJSON payload)
+                            => T.Text -- ^ The unique device token must be provided
+                            -> payload -- ^ The payload of arbitrary type
+                            -> PushyPostRequestBody payload
 defaultPushyPostRequestBody deviceToken body =
-    let pprbTo = deviceToken
-        pprbBodyData = body
-        pprbTimeToLive = 2592000
-        pprbContentAvailable = False
-        pprbMutableContent = False
-        pprbNotification = Nothing
-    in PushyPostRequestBody{..}
+    PushyPostRequestBody
+        { pprbTo = deviceToken
+        , pprbBodyData = body
+        , pprbTimeToLive = 2592000
+        , pprbContentAvailable = False
+        , pprbMutableContent = False
+        , pprbNotification = Nothing
+        }

--- a/src/Types/PushyRequest.hs
+++ b/src/Types/PushyRequest.hs
@@ -1,0 +1,136 @@
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Types.PushyRequest
+    ( BodyData
+    , IosNotification (..)
+    , defaultIosNotification
+    , PushyPostRequestBody (..)
+    , defaultPushyPostRequestBody
+    ) where
+
+import           Data.Aeson
+import           Data.Map
+
+import qualified Data.ByteString       as B
+import qualified Data.ByteString.Char8 as B8
+import qualified Data.ByteString.Lazy  as L
+import qualified Data.Text             as D
+import qualified Data.Text             as T
+
+
+-- | Type to represent the body containing the message
+newtype BodyData = BodyData T.Text deriving (Show)
+
+instance ToJSON BodyData where
+    toJSON (BodyData msg) = object ["message" .= toJSON msg]
+
+-- | Type to represent the iOS notification settings;
+-- see https://pushy.me/docs/api/send-notifications for the complete documentation
+data IosNotification = IosNotification
+    {
+      -- | Main alert message
+      inBody         :: T.Text
+
+      -- | Number to display as badge of the app icon
+    , inBadge        :: Maybe Int
+
+      -- | Name of soundfile that should be played when a PN is received
+    , inSound        :: Maybe T.Text
+
+      -- | String describing pupose of notification
+    , inTitle        :: Maybe T.Text
+
+      -- | String used to determine custom notification UI
+    , inCategory     :: Maybe T.Text
+
+    -- | Localization key present in app's 'Localizable.strings' file
+    , inLocKey       :: Maybe T.Text
+
+    -- | Replacement strings to subsitute in place of the '%@' placeholders of the
+    -- localization string
+    , inLocArgs      :: [T.Text]
+
+    -- | Localization key present in app's 'Localizable.strings' file
+    , inTitleLocKey  :: Maybe T.Text
+
+    -- | Replacement strings to subsitute in place of the '%@' placeholders of the
+    -- localization string
+    , inTitleLocArgs :: [T.Text]
+    } deriving (Show)
+
+instance ToJSON IosNotification where
+    toJSON IosNotification{..} =
+        object [ "body"           .= inBody
+               , "badge"          .= inBadge
+               , "sound"          .= inSound
+               , "title"          .= inTitle
+               , "category"       .= inCategory
+               , "loc_key"        .= inLocKey
+               , "loc_args"       .= inLocArgs
+               , "title_loc_key"  .= inTitleLocKey
+               , "title_loc_args" .= inTitleLocArgs
+               ]
+
+-- | Default iOS notification setting
+defaultIosNotification :: T.Text -> IosNotification
+defaultIosNotification body =
+    let inBody =  body
+        inBadge = Nothing
+        inSound = Nothing
+        inTitle = Nothing
+        inCategory = Nothing
+        inLocKey = Nothing
+        inLocArgs = []
+        inTitleLocKey = Nothing
+        inTitleLocArgs = []
+    in IosNotification {..}
+
+
+-- | Type to represent the body of an HTTP POST request to the Pushy API;
+--  see https://pushy.me/docs/api/send-notifications for the complete documentation
+data PushyPostRequestBody = PushyPostRequestBody
+    {
+      -- | The unique token associated with the device to which the notification is sent
+      pprbTo               :: T.Text
+
+      -- | The payload to be sent to devices
+    , pprbBodyData         :: BodyData -- TODO: This should be a Map String String
+
+    -- | How long the push notification should be kept alive
+    , pprbTimeToLive       :: Maybe Int
+
+    -- | When set to 'true', invokes app's notification handler even if app is running in
+    -- the background
+    , pprbContentAvailable :: Maybe Bool
+
+    -- | When set to 'true', the app's notification service extension is invoked even if
+    -- the app is running in the background
+    , pprbMutableContent   :: Maybe Bool
+
+    -- | Notification options for iOS
+    , pprbNotification     :: Maybe IosNotification
+    } deriving (Show)
+
+instance ToJSON PushyPostRequestBody where
+    toJSON PushyPostRequestBody{..} =
+        object [ "to"                .= pprbTo
+               , "data"              .= pprbBodyData
+               , "time_to_live"      .= pprbTimeToLive
+               , "content_available" .= pprbContentAvailable
+               , "mutable_content"   .= pprbMutableContent
+               , "notification"      .= pprbNotification
+               ]
+
+defaultPushyPostRequestBody :: T.Text -- ^ The unique device token must be provided
+                            -> BodyData -- ^ The body must be provided
+                            -> PushyPostRequestBody
+defaultPushyPostRequestBody deviceToken body =
+    let pprbTo = deviceToken
+        pprbBodyData = body
+        pprbTimeToLive = Nothing
+        pprbContentAvailable = Nothing
+        pprbMutableContent = Nothing
+        pprbNotification = Nothing
+    in PushyPostRequestBody{..}

--- a/src/Types/PushyRequest.hs
+++ b/src/Types/PushyRequest.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Types.PushyRequest
-    ( BodyData
+    ( BodyData (..)
     , IosNotification (..)
     , defaultIosNotification
     , PushyPostRequestBody (..)
@@ -98,16 +98,17 @@ data PushyPostRequestBody = PushyPostRequestBody
       -- | The payload to be sent to devices
     , pprbBodyData         :: BodyData -- TODO: This should be a Map String String
 
-    -- | How long the push notification should be kept alive
-    , pprbTimeToLive       :: Maybe Int
+    -- | How long the push notification should be kept alive; the default is set to a month
+    -- with 30 days
+    , pprbTimeToLive       :: Int
 
     -- | When set to 'true', invokes app's notification handler even if app is running in
-    -- the background
-    , pprbContentAvailable :: Maybe Bool
+    -- the background; default is 'False'
+    , pprbContentAvailable :: Bool
 
     -- | When set to 'true', the app's notification service extension is invoked even if
-    -- the app is running in the background
-    , pprbMutableContent   :: Maybe Bool
+    -- the app is running in the background; default is 'False'
+    , pprbMutableContent   :: Bool
 
     -- | Notification options for iOS
     , pprbNotification     :: Maybe IosNotification
@@ -129,8 +130,8 @@ defaultPushyPostRequestBody :: T.Text -- ^ The unique device token must be provi
 defaultPushyPostRequestBody deviceToken body =
     let pprbTo = deviceToken
         pprbBodyData = body
-        pprbTimeToLive = Nothing
-        pprbContentAvailable = Nothing
-        pprbMutableContent = Nothing
+        pprbTimeToLive = 2592000
+        pprbContentAvailable = False
+        pprbMutableContent = False
         pprbNotification = Nothing
     in PushyPostRequestBody{..}

--- a/src/Types/PushyRequest.hs
+++ b/src/Types/PushyRequest.hs
@@ -119,8 +119,7 @@ instance (ToJSON payload) => ToJSON (PushyPostRequestBody payload) where
 -- | The default value for a pushy post request body. Use this to construct custom
 -- Pushy post request bodies. Note that a 'PushyPostRequestBody' value must always have
 -- device token and a message.
-defaultPushyPostRequestBody :: (ToJSON payload)
-                            => T.Text -- ^ The unique device token must be provided
+defaultPushyPostRequestBody :: T.Text -- ^ The unique device token must be provided
                             -> payload -- ^ The payload of arbitrary type
                             -> PushyPostRequestBody payload
 defaultPushyPostRequestBody deviceToken body =

--- a/src/Types/PushyResponse.hs
+++ b/src/Types/PushyResponse.hs
@@ -46,7 +46,7 @@ data PushyResult =
   -- code and the unique ID of the PN as arguments
     PushyResultSuccesfulRequest Status SuccessInfo
 
-    -- | Represents HTTP response with a 300 / 400 / 500 status code; constructor takes
+    -- | Represents HTTP response with a 3xx / 4xx / 5xx status code; constructor takes
     -- the HTTP status code and the failure info of type 'FailureInfo' as arguments
     | PushyResultFailedRequest Status FailureInfo
 

--- a/src/Types/PushyResponse.hs
+++ b/src/Types/PushyResponse.hs
@@ -1,0 +1,72 @@
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
+
+module Types.PushyResponse
+    ( SuccessInfo (..)
+    , FailureInfo (..)
+    , PushyResult (..)
+    , decodePushyResponse
+    ) where
+
+import           Data.Aeson
+import           Data.Map
+import           Network.HTTP.Client
+import           Network.HTTP.Simple
+import           Network.HTTP.Types
+
+import qualified Data.ByteString       as B
+import qualified Data.ByteString.Char8 as B8
+import qualified Data.ByteString.Lazy  as L
+import qualified Data.Text             as D
+import qualified Data.Text             as T
+
+
+-- | Newtype wrapping the ID of a PN that was succesfully sent by Pushy
+newtype SuccessInfo = SuccessInfo T.Text deriving (Show)
+
+instance FromJSON SuccessInfo where
+    parseJSON = withObject "SuccessInfo" $ \v -> SuccessInfo <$> v .: "id"
+
+-- | Record type to capture releveant information of a failure HTTP request to the Pushy
+-- API
+data FailureInfo = FailureInfo
+    {
+      -- | Specific error codes provided by Pushy;
+      -- see the documentation for more info: https://pushy.me/docs/api/send-notifications
+      prfPushyErrorCode        :: T.Text
+
+      -- | A detailed description of the exact error; also provided by the Pushy API
+    , prfPushyErrorDescription :: T.Text
+    } deriving (Show)
+
+instance FromJSON FailureInfo where
+    parseJSON = withObject "FailureInfo" $ \v -> FailureInfo
+        <$> v .: "code"
+        <*> v .: "error"
+
+-- | Sum type to capture possible results of the pushy push notification
+data PushyResult =
+  -- | Represents HTTP responses with a 200 status code; wraps the unique ID of the PN
+    PushyResultSuccesful Status SuccessInfo
+
+    -- | Represents HTTP response with a 300 / 400 / 500 status code; wraps
+    -- the HTTP status code and the failure info of type 'FailureInfo'
+    | PushyResultHttpFailure Status FailureInfo
+
+    -- | Represents other possible failures
+    | PushyResultOtherFailure T.Text
+    deriving (Show)
+
+-- | Function to decode the Pushy API HTTP response
+decodePushyResponse :: Response L.ByteString -> PushyResult
+decodePushyResponse res =
+    let resStat = responseStatus res
+        resBody = responseBody res
+    in if statusCode resStat == 200
+       then case decode @SuccessInfo resBody of
+                Just info -> PushyResultSuccesful resStat info
+                Nothing   -> PushyResultOtherFailure "Failed to parse response"
+       else case decode @FailureInfo resBody of
+                Just info -> PushyResultHttpFailure resStat info
+                Nothing   -> PushyResultOtherFailure "Failed to parse response"

--- a/stack.yaml
+++ b/stack.yaml
@@ -20,7 +20,7 @@ resolver: lts-14.27
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-16.8
+# resolver: lts-16.8
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.


### PR DESCRIPTION
This PR will close #1 and will close #2, and does the following: 
- Define the types corresponding the request body schema specified in the [pushy documentation](https://pushy.me/docs/api/send-notifications)
- Define types to decode the Pushy response, and to capture all possible values that the `makePushyPostRequest` function might result in 
- Refactor the modules to provide a logical separation of code 

Reviewing this PR, some help with the following would be appreciated:
- How do we better define error types and handle them? Currently I've represented the error states as part of the `PushyResult` sum type. 
- What should be tested (the tests will be written as part of the next PR) 
- Are there any other changes to the code that should be made? 

The aim is to get this library more or less production ready ASAP. 